### PR TITLE
Let logchoose return a scalar value instead of an array wrapping the scalar

### DIFF
--- a/DIAMOnD.py
+++ b/DIAMOnD.py
@@ -160,7 +160,7 @@ def logchoose(n, k, gamma_ln):
     lgn1 = gamma_ln[n + 1]
     lgk1 = gamma_ln[k + 1]
     lgnk1 = gamma_ln[n - k + 1]
-    return lgn1 - [lgnk1 + lgk1]
+    return lgn1 - (lgnk1 + lgk1)
 
 
 # =============================================================================


### PR DESCRIPTION
While profiling the runtime of DIAMOnD I realized that a lot of time is being spent in the function `logchoose`. When I brought this up to @Karollus we noticed the odd syntax of the [return statement](https://github.com/dinaghiassian/DIAMOnD/blob/24379748c5ee34f477a968ba3f1c0b325ff0614f/DIAMOnD.py#L163), as it did not seem to be standard python. Thus I investigated whether this might be the reason for the hotspot.

It turns out that a scalar float64 return value always gets wrapped into a numpy array due to the square brackets. This seems to be unnecessary overhead, as switching from square brackets to regular parentheses gives exactly the same results.

Further profiling also revealed that removing the overhead of wrapping the return value in an array every time indeed decreases the time spent in `logchoose` by quite a bit. In my tests using a PPI containing ~17k nodes, ~340k edges, a seed set containing ~800 nodes and X=100, it decreased the time spent in it by ~88% and the total execution time by ~57%. 

Below are the relevant parts of the profiling logs and the commands used for profiling, with the total time and the time spent in logchoose in bold:

Top 10 for the non-fixed version, ordered by total time spent in the given function (excluding time made in calls to sub-functions).
<pre>
$ python3 -m cProfile -s 'tottime' NOFIX-DIAMOnD.py PPI SEEDS 100 2

 results have been saved to 'first_100_added_weight_2.txt' 

         8500870 function calls (8491871 primitive calls) in <b>37.224 seconds</b>

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  <b>4569171   20.271    0.000   20.271    0.000 NOFIX-DIAMOnD.py:157(logchoose)</b>
      100    7.875    0.079    7.891    0.079 NOFIX-DIAMOnD.py:212(reduce_not_in_cluster_nodes)
  1523057    4.480    0.000   24.750    0.000 NOFIX-DIAMOnD.py:167(gauss_hypergeom)
     6700    2.801    0.000   27.551    0.004 NOFIX-DIAMOnD.py:174(pvalue)
   337971    0.456    0.000    0.536    0.000 graph.py:820(add_edge)
        1    0.233    0.233    0.870    0.870 NOFIX-DIAMOnD.py:89(read_input)
    16689    0.158    0.000    0.165    0.000 reportviews.py:351(__call__)
        1    0.099    0.099    0.294    0.294 NOFIX-DIAMOnD.py:199(get_neighbors_and_degrees)
   339969    0.064    0.000    0.064    0.000 {method 'split' of 'str' objects}
      680    0.052    0.000    0.052    0.000 {built-in method marshal.loads}
(...)
</pre>

The same for the fixed version:
<pre>
$ python3 -m cProfile -s 'tottime' DIAMOnD.py PPI SEEDS 100 2

 results have been saved to 'first_100_added_weight_2.txt' 

         8500870 function calls (8491871 primitive calls) in <b>15.913 seconds</b>

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      100    7.803    0.078    7.818    0.078 DIAMOnD.py:212(reduce_not_in_cluster_nodes)
  1523057    3.307    0.000    5.633    0.000 DIAMOnD.py:167(gauss_hypergeom)
  <b>4569171    2.325    0.000    2.325    0.000 DIAMOnD.py:157(logchoose)</b>
     6700    0.704    0.000    6.337    0.001 DIAMOnD.py:174(pvalue)
   337971    0.459    0.000    0.540    0.000 graph.py:820(add_edge)
        1    0.232    0.232    0.872    0.872 DIAMOnD.py:89(read_input)
    16689    0.152    0.000    0.159    0.000 reportviews.py:351(__call__)
        1    0.096    0.096    0.284    0.284 DIAMOnD.py:199(get_neighbors_and_degrees)
   339969    0.064    0.000    0.064    0.000 {method 'split' of 'str' objects}
      680    0.053    0.000    0.053    0.000 {built-in method marshal.loads}
(...)
</pre>

Also I wanted to let you know that while checking the results for equality I realized that the computed scores are deterministic, but the labeling for two scores can "swap" if the nodes have the same `k` and `kb` values in the algorithm. 
This can be fixed by changing [this line](https://github.com/dinaghiassian/DIAMOnD/blob/24379748c5ee34f477a968ba3f1c0b325ff0614f/DIAMOnD.py#L215) to `for node in sorted(not_in_cluster)`. This fix also does not seem to slow down the computation. However I did not test this very well and I don't know whether ties are actually intended to be resolved this way, thus I didn't want to open a separate pull request for this issue.

As this is my first pull request I'm not sure whether you need any more information, so please tell me if that's the case. Thanks! :)